### PR TITLE
Rename "Leave Game" to "Resign"

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # In Progress
 
-- [ ] Rename Leave Game to "Resign"
+- [x] Rename Leave Game to "Resign"
 - [ ] In GameExtensions use getName instead of .toString which means also getting the type correct for players
 - [ ] Check if change in GameRepository.fillLocalStates is good. There is still a problem with state not correctly refreshed in menu and lobby game.turn out of date/stale and the fix that fixes
   in game is breaking the fix (commented out) that was fixing the bug in configuration mode.

--- a/app/src/main/java/com/cauchymop/goblob/ui/MainActivity.java
+++ b/app/src/main/java/com/cauchymop/goblob/ui/MainActivity.java
@@ -170,7 +170,7 @@ public class MainActivity extends AppCompatActivity
         if (currentGame != null) {
             isRemoteGame = androidGameRepository.getGameDatas().isRemoteGame(currentGame);
         }
-        menu.findItem(R.id.menu_leave_game).setVisible(isRemoteGame);
+        menu.findItem(R.id.menu_resign_game).setVisible(isRemoteGame);
 
         return super.onPrepareOptionsMenu(menu);
     }
@@ -195,7 +195,7 @@ public class MainActivity extends AppCompatActivity
             if (com.cauchymop.goblob.BuildConfig.DEBUG) {
                 androidGameRepository.clearCache();
             }
-        } else if (id == R.id.menu_leave_game) {
+        } else if (id == R.id.menu_resign_game) {
             PlayGameData.GameData currentGame = androidGameRepository.getCurrentGame();
             if (currentGame != null) {
                 androidGameRepository.leaveGame(currentGame.getMatchId());

--- a/app/src/main/res/menu/game_menu.xml
+++ b/app/src/main/res/menu/game_menu.xml
@@ -52,8 +52,8 @@
         android:visible="true"
         android:title="@string/about"/>
     <item
-        android:id="@+id/menu_leave_game"
-        android:title="@string/leave_game"
+        android:id="@+id/menu_resign_game"
+        android:title="@string/resign"
         android:visible="false"
         app:showAsAction="never"/>
     <item

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -45,5 +45,4 @@
     <string name="about_text"><![CDATA[<h1>%1$s</h1>Version %2$s<br>par CauchyMop<br>(Jérôme Abela & Olivier Bonal)<br><div>Icone par <a href="http://www.onlinewebfonts.com/icon">Icon Fonts</a> sous license CC&nbsp;BY&nbsp;3.0</div>]]></string>
     <string name="waiting_for_opponent">En attente de partenaire</string>
     <string name="playing">Partie en cours</string>
-    <string name="leave_game">Quitter la partie</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,7 +60,6 @@
   <string name="about_text"><![CDATA[<h1>%1$s</h1>Version %2$s<br>by CauchyMop<br>(Jérôme Abela & Olivier Bonal)<br><div>Icon made from <a href="http://www.onlinewebfonts.com/icon">Icon Fonts</a> is licensed by CC&nbsp;BY&nbsp;3.0</div>]]></string>
   <string name="waiting_for_opponent">Waiting for opponent</string>
   <string name="playing">Playing</string>
-  <string name="leave_game">Leave Game</string>
 
   <string-array name="handicap_values" translatable="false">
     <item>@string/handicap_even</item>


### PR DESCRIPTION
This change renames the "Leave Game" menu item to "Resign" as requested in `TODO.md`. It updates the menu resource ID and title, replaces usages in `MainActivity.java`, and removes the redundant `leave_game` string resource. The existing `@string/resign` resource is used. Testing confirms the build passes and no regressions in unit tests.

---
*PR created automatically by Jules for task [1023574182533944341](https://jules.google.com/task/1023574182533944341) started by @obonal*