### PR TITLE
Send push token to lobby server

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     implementation(libs.protobuf.java)
     implementation(libs.firebase.core)
     implementation(libs.firebase.analytics)
+    implementation(libs.firebase.messaging)
     implementation(libs.kotlin.stdlib.jdk7)
     implementation(libs.crashlytics)
 

--- a/app/src/main/java/com/cauchymop/goblob/ui/AndroidGameRepository.kt
+++ b/app/src/main/java/com/cauchymop/goblob/ui/AndroidGameRepository.kt
@@ -14,6 +14,7 @@ import com.cauchymop.goblob.model.GoogleAccountManager
 import com.cauchymop.goblob.proto.PlayGameData.GameData
 import com.cauchymop.goblob.proto.PlayGameData.GameList
 import com.crashlytics.android.Crashlytics
+import com.google.firebase.messaging.FirebaseMessaging
 import com.google.protobuf.TextFormat
 import dagger.Lazy
 import java.util.UUID
@@ -64,6 +65,23 @@ constructor(
         })
         // TODO: Pass Google Signin to LobbyClient somehow when isSignInComplete?
         lobbyClient.addListener(this)
+        fetchPushToken()
+    }
+
+    private fun fetchPushToken() {
+        try {
+            FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+                if (task.isSuccessful) {
+                    val token = task.result
+                    log("FCM token: $token")
+                    lobbyClient.setPushToken(token)
+                } else {
+                    log("FCM token fetch failed: ${task.exception}")
+                }
+            }
+        } catch (e: Exception) {
+            log("Error fetching FCM token: ${e.message}")
+        }
     }
 
     private fun onGoogleSignIn() {

--- a/app/src/main/java/com/cauchymop/goblob/ui/AndroidGameRepository.kt
+++ b/app/src/main/java/com/cauchymop/goblob/ui/AndroidGameRepository.kt
@@ -65,6 +65,9 @@ constructor(
         })
         // TODO: Pass Google Signin to LobbyClient somehow when isSignInComplete?
         lobbyClient.addListener(this)
+    }
+
+    override fun onGameTypeReceived(gameType: net.yura.lobby.model.GameType) {
         fetchPushToken()
     }
 
@@ -74,7 +77,7 @@ constructor(
                 if (task.isSuccessful) {
                     val token = task.result
                     log("FCM token: $token")
-                    lobbyClient.setPushToken(token)
+                    lobbyClient.sendPushToken(token)
                 } else {
                     log("FCM token fetch failed: ${task.exception}")
                 }

--- a/app/src/main/java/com/cauchymop/goblob/ui/AndroidGameRepository.kt
+++ b/app/src/main/java/com/cauchymop/goblob/ui/AndroidGameRepository.kt
@@ -67,7 +67,7 @@ constructor(
         lobbyClient.addListener(this)
     }
 
-    override fun onGameTypeReceived(gameType: net.yura.lobby.model.GameType) {
+    override fun onGameTypeReceived() {
         fetchPushToken()
     }
 

--- a/goblobBase/src/main/java/com/cauchymop/goblob/lobby/LobbyClient.kt
+++ b/goblobBase/src/main/java/com/cauchymop/goblob/lobby/LobbyClient.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.map
 import net.yura.lobby.client.LobbyClient
 import net.yura.lobby.client.LobbyCom
+import net.yura.lobby.client.PushLobbyClient
 import net.yura.lobby.model.Game
 import net.yura.lobby.model.GameType
 import net.yura.lobby.model.Player
@@ -18,6 +19,7 @@ import java.util.concurrent.ConcurrentHashMap
 class LobbyClient(uuid: String, appName: String, version: String) : LobbyClient {
 
     private var myPlayerName: String = ""
+    private var pushToken: String? = null
     private val mycom: LobbyCom = LobbyCom(uuid, appName, version)
     private val listeners = mutableListOf<LobbyClientListener>()
     var gameType: GameType? = null
@@ -89,6 +91,20 @@ class LobbyClient(uuid: String, appName: String, version: String) : LobbyClient 
         mycom.sendGameMessage(gameId, message)
     }
 
+    fun setPushToken(token: String) {
+        this.pushToken = token
+        maybeSendPushToken()
+    }
+
+    private fun maybeSendPushToken() {
+        val gameType = this.gameType
+        val pushToken = this.pushToken
+        if (gameType != null && pushToken != null) {
+            println("OLIVIER: setPushToken $pushToken")
+            mycom.setPushToken(PushLobbyClient.PUSH_SYSTEM_FCM, gameType, pushToken)
+        }
+    }
+
 
     override fun connected() {
         println("OLIVIER: connected!")
@@ -119,7 +135,9 @@ class LobbyClient(uuid: String, appName: String, version: String) : LobbyClient 
     override fun addGameType(types: MutableList<Any?>) {
         val gameTypes = types.filterIsInstance<GameType>()
         println("addGameType: types = $gameTypes")
-        gameType = gameTypes.first { it.name == "Go Blob" }
+        val ourGameType = gameTypes.first { it.name == "Go Blob" }
+        gameType = ourGameType
+        maybeSendPushToken()
         mycom.getGames(gameType)
     }
 

--- a/goblobBase/src/main/java/com/cauchymop/goblob/lobby/LobbyClient.kt
+++ b/goblobBase/src/main/java/com/cauchymop/goblob/lobby/LobbyClient.kt
@@ -19,7 +19,6 @@ import java.util.concurrent.ConcurrentHashMap
 class LobbyClient(uuid: String, appName: String, version: String) : LobbyClient {
 
     private var myPlayerName: String = ""
-    private var pushToken: String? = null
     private val mycom: LobbyCom = LobbyCom(uuid, appName, version)
     private val listeners = mutableListOf<LobbyClientListener>()
     var gameType: GameType? = null
@@ -91,17 +90,11 @@ class LobbyClient(uuid: String, appName: String, version: String) : LobbyClient 
         mycom.sendGameMessage(gameId, message)
     }
 
-    fun setPushToken(token: String) {
-        this.pushToken = token
-        maybeSendPushToken()
-    }
-
-    private fun maybeSendPushToken() {
+    fun sendPushToken(token: String) {
         val gameType = this.gameType
-        val pushToken = this.pushToken
-        if (gameType != null && pushToken != null) {
-            println("OLIVIER: setPushToken $pushToken")
-            mycom.setPushToken(PushLobbyClient.PUSH_SYSTEM_FCM, gameType, pushToken)
+        if (gameType != null) {
+            println("OLIVIER: setPushToken $token")
+            mycom.setPushToken(PushLobbyClient.PUSH_SYSTEM_FCM, gameType, token)
         }
     }
 
@@ -137,7 +130,7 @@ class LobbyClient(uuid: String, appName: String, version: String) : LobbyClient 
         println("addGameType: types = $gameTypes")
         val ourGameType = gameTypes.first { it.name == "Go Blob" }
         gameType = ourGameType
-        maybeSendPushToken()
+        listeners.forEach { it.onGameTypeReceived(ourGameType) }
         mycom.getGames(gameType)
     }
 
@@ -215,4 +208,5 @@ class LobbyClient(uuid: String, appName: String, version: String) : LobbyClient 
 interface LobbyClientListener {
     fun onAddOrUpdateLobbyGame(game: Game)
     fun onLobbyGameDataChanged(gameId: Int, gameDataBytes: ByteArray?)
+    fun onGameTypeReceived(gameType: GameType) {}
 }

--- a/goblobBase/src/main/java/com/cauchymop/goblob/lobby/LobbyClient.kt
+++ b/goblobBase/src/main/java/com/cauchymop/goblob/lobby/LobbyClient.kt
@@ -91,11 +91,8 @@ class LobbyClient(uuid: String, appName: String, version: String) : LobbyClient 
     }
 
     fun sendPushToken(token: String) {
-        val gameType = this.gameType
-        if (gameType != null) {
-            println("OLIVIER: setPushToken $token")
-            mycom.setPushToken(PushLobbyClient.PUSH_SYSTEM_FCM, gameType, token)
-        }
+        println("OLIVIER: setPushToken $token")
+        mycom.setPushToken(PushLobbyClient.PUSH_SYSTEM_FCM, gameType!!, token)
     }
 
 
@@ -128,9 +125,8 @@ class LobbyClient(uuid: String, appName: String, version: String) : LobbyClient 
     override fun addGameType(types: MutableList<Any?>) {
         val gameTypes = types.filterIsInstance<GameType>()
         println("addGameType: types = $gameTypes")
-        val ourGameType = gameTypes.first { it.name == "Go Blob" }
-        gameType = ourGameType
-        listeners.forEach { it.onGameTypeReceived(ourGameType) }
+        gameType = gameTypes.first { it.name == "Go Blob" }
+        listeners.forEach { it.onGameTypeReceived() }
         mycom.getGames(gameType)
     }
 
@@ -208,5 +204,5 @@ class LobbyClient(uuid: String, appName: String, version: String) : LobbyClient 
 interface LobbyClientListener {
     fun onAddOrUpdateLobbyGame(game: Game)
     fun onLobbyGameDataChanged(gameId: Int, gameDataBytes: ByteArray?)
-    fun onGameTypeReceived(gameType: GameType) {}
+    fun onGameTypeReceived() {}
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ agp = "9.0.1"
 crashlytics = "2.10.1"
 daggerVersion = "2.57"
 firebaseAnalytics = "23.0.0"
+firebaseMessaging = "24.1.0"
 firebaseCore = "21.1.1"
 grpcStub = "1.73.0"
 guavaVersion = "33.4.8-android"
@@ -34,6 +35,7 @@ dagger-android-processor = { module = "com.google.dagger:dagger-android-processo
 dagger-android-support = { module = "com.google.dagger:dagger-android-support", version.ref = "daggerVersion" }
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "daggerVersion" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics", version.ref = "firebaseAnalytics" }
+firebase-messaging = { module = "com.google.firebase:firebase-messaging", version.ref = "firebaseMessaging" }
 firebase-core = { module = "com.google.firebase:firebase-core", version.ref = "firebaseCore" }
 grpc-protobuf = { module = "io.grpc:grpc-protobuf", version.ref = "grpcStub" }
 grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpcStub" }


### PR DESCRIPTION
Implemented push token registration with the lobby server. This involved adding the Firebase Messaging dependency, retrieving the FCM token on the Android side, and updating the `LobbyClient` to communicate this token to the server once the specific game type has been identified. This ensures that push notifications can be correctly routed by the lobby server.

---
*PR created automatically by Jules for task [320690136006892819](https://jules.google.com/task/320690136006892819) started by @sdyura*